### PR TITLE
Integrate API module and auth store

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -48,7 +48,7 @@ export default function SettingsPage() {
   const profileForm = useForm<z.infer<typeof profileFormSchema>>({
     resolver: zodResolver(profileFormSchema),
     defaultValues: {
-      name: user?.name || "",
+      name: user?.full_name || "",
       email: user?.email || "",
     },
   })

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -571,10 +571,8 @@ export default function Sidebar({ open, setOpen, setActiveView }: SidebarProps) 
                     <User className="h-4 w-4" />
                   </div>
                   <div className="text-sm">
-                    <p className="font-medium">{user?.name || "Usuario"}</p>
-                    <p className="text-xs text-slate-500">
-                      Plan {user?.plan === "free" ? "Gratuito" : user?.plan === "premium" ? "Premium" : "Pro"}
-                    </p>
+                    <p className="font-medium">{user?.full_name || "Usuario"}</p>
+                    <p className="text-xs text-slate-500">{user?.email}</p>
                   </div>
                 </div>
                 <div className="flex items-center gap-1">

--- a/lib/rsvpApi.ts
+++ b/lib/rsvpApi.ts
@@ -1,0 +1,155 @@
+export interface RegisterRequest {
+  email: string
+  password: string
+  full_name: string
+}
+
+export interface RegisterResponse {
+  id: string
+  email: string
+  full_name: string
+  is_active: boolean
+  created_at: string
+}
+
+export interface LoginRequest {
+  username: string
+  password: string
+}
+
+export interface LoginResponse {
+  access_token: string
+  token_type: string
+}
+
+export interface User extends RegisterResponse {}
+
+export interface RsvpRequest {
+  topic: string
+}
+
+export interface RsvpSession {
+  id: string
+  text: string
+  words: string[]
+  // additional fields may exist
+  [key: string]: any
+}
+
+export interface QuizQuestion {
+  id: string
+  question_text: string
+  question_type: string
+  options: string[]
+  correct_answer: string
+  explanation: string
+}
+
+export interface QuizResponse {
+  rsvp_session_id: string
+  questions: QuizQuestion[]
+}
+
+export interface QuizValidateRequest {
+  rsvp_session_id: string
+  answers: {
+    question_id: string
+    user_answer: string
+  }[]
+}
+
+export interface QuizValidateResponse {
+  rsvp_session_id: string
+  overall_score: number
+  results: {
+    question_id: string
+    is_correct: boolean
+    feedback: string
+    correct_answer: string
+  }[]
+}
+
+export interface StatsResponse {
+  user_id: string
+  overall_stats: {
+    total_sessions_read: number
+    total_reading_time_seconds: number
+    total_words_read: number
+    average_wpm: number
+    total_quizzes_taken: number
+    average_quiz_score: number
+  }
+  recent_sessions_stats: {
+    session_id: string
+    text_snippet: string
+    word_count: number
+    reading_time_seconds: number
+    wpm: number
+    quiz_taken: boolean
+    quiz_score: number
+    ai_text_difficulty: string
+    ai_estimated_ideal_reading_time_seconds: number
+    created_at: string
+  }[]
+  personalized_feedback: string | null
+}
+
+export interface AssistantRequest {
+  query: string
+  rsvp_session_id: string
+}
+
+export interface AssistantResponse {
+  response: string
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  token?: string,
+): Promise<T> {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (options.body && typeof options.body !== 'string') {
+    options.body = JSON.stringify(options.body)
+  }
+  const res = await fetch(`${API_URL}${endpoint}`, { ...options, headers })
+  if (!res.ok) {
+    let detail: string | undefined
+    try {
+      const data = await res.json()
+      detail = data.detail || JSON.stringify(data)
+    } catch {
+      detail = res.statusText
+    }
+    throw new Error(detail)
+  }
+  return res.json()
+}
+
+export const rsvpApi = {
+  register: (data: RegisterRequest) =>
+    request<RegisterResponse>('/auth/register', { method: 'POST', body: data }),
+  login: (data: LoginRequest) =>
+    request<LoginResponse>('/auth/login', { method: 'POST', body: data }),
+  me: (token: string) => request<User>('/auth/me', { method: 'GET' }, token),
+  createRsvp: (data: RsvpRequest, token: string) =>
+    request<RsvpSession>('/api/rsvp', { method: 'POST', body: data }, token),
+  getRsvp: (id: string, token: string) =>
+    request<RsvpSession>(`/api/rsvp/${id}`, { method: 'GET' }, token),
+  createQuiz: (data: { rsvp_session_id: string }, token: string) =>
+    request<QuizResponse>('/api/quiz', { method: 'POST', body: data }, token),
+  validateQuiz: (data: QuizValidateRequest, token: string) =>
+    request<QuizValidateResponse>(
+      '/api/quiz/validate',
+      { method: 'POST', body: data },
+      token,
+    ),
+  getStats: (token: string) =>
+    request<StatsResponse>('/api/stats', { method: 'GET' }, token),
+  assistant: (data: AssistantRequest, token: string) =>
+    request<AssistantResponse>('/api/assistant', { method: 'POST', body: data }, token),
+}
+


### PR DESCRIPTION
## Summary
- add typed API wrapper `rsvpApi` for FastAPI backend
- rewrite Zustand `useAuthStore` to use backend auth endpoints
- adjust sidebar and settings page to new user fields

## Testing
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee0091b8832faea6c3ce5a1db615