### PR TITLE
Fix session sync and Spanish UI

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -218,7 +218,7 @@ export default function Dashboard({ setActiveView }: DashboardProps) {
             )}
             {isMobile && (
               <TabsTrigger value="stats" className="flex items-center gap-1 text-sm px-2">
-                <Activity className="h-4 w-4" /> Stats
+                <Activity className="h-4 w-4" /> Estadísticas
               </TabsTrigger>
             )}
           </TabsList>

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -217,7 +217,7 @@ const CarouselPrevious = React.forwardRef<
       {...props}
     >
       <ArrowLeft className="h-4 w-4" />
-      <span className="sr-only">Previous slide</span>
+      <span className="sr-only">Diapositiva anterior</span>
     </Button>
   )
 })
@@ -246,7 +246,7 @@ const CarouselNext = React.forwardRef<
       {...props}
     >
       <ArrowRight className="h-4 w-4" />
-      <span className="sr-only">Next slide</span>
+      <span className="sr-only">Siguiente diapositiva</span>
     </Button>
   )
 })

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -64,13 +64,13 @@ const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label="Ir a la página anterior"
     size="default"
     className={cn("gap-1 pl-2.5", className)}
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
+    <span>Anterior</span>
   </PaginationLink>
 )
 PaginationPrevious.displayName = "PaginationPrevious"
@@ -80,12 +80,12 @@ const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label="Ir a la página siguiente"
     size="default"
     className={cn("gap-1 pr-2.5", className)}
     {...props}
   >
-    <span>Next</span>
+    <span>Siguiente</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 )
@@ -101,7 +101,7 @@ const PaginationEllipsis = ({
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
+    <span className="sr-only">Más páginas</span>
   </span>
 )
 PaginationEllipsis.displayName = "PaginationEllipsis"

--- a/components/windows/stats-window.tsx
+++ b/components/windows/stats-window.tsx
@@ -51,14 +51,14 @@ export default function StatsWindow({ windowData }: StatsWindowProps) {
   return (
     <WindowFrame
       id={windowData.id}
-      title="Estadísticas y Feedback"
+      title="Estadísticas y Retroalimentación"
       initialWidth={windowData.position.width}
       initialHeight={windowData.position.height}
       initialX={windowData.position.x}
       initialY={windowData.position.y}    >
       <div className="space-y-6">
         <div className={`flex items-center gap-2 ${isMobile ? 'flex-col' : 'justify-between'}`}>
-          <h2 className={`font-bold ${isMobile ? 'text-lg' : 'text-xl'}`}>Estadísticas y Feedback</h2>
+          <h2 className={`font-bold ${isMobile ? 'text-lg' : 'text-xl'}`}>Estadísticas y Retroalimentación</h2>
           <Button 
             variant="outline" 
             size={isMobile ? "default" : "sm"}
@@ -72,10 +72,10 @@ export default function StatsWindow({ windowData }: StatsWindowProps) {
         <Tabs defaultValue="stats">
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="stats" className={`flex items-center gap-1 ${isMobile ? 'text-sm' : ''}`}>
-              <BarChart className="h-4 w-4" /> {isMobile ? 'Stats' : 'Estadísticas'}
+              <BarChart className="h-4 w-4" /> {isMobile ? 'Estadísticas' : 'Estadísticas'}
             </TabsTrigger>
             <TabsTrigger value="feedback" className={`flex items-center gap-1 ${isMobile ? 'text-sm' : ''}`}>
-              <BookOpen className="h-4 w-4" /> Feedback
+              <BookOpen className="h-4 w-4" /> Retroalimentación
             </TabsTrigger>
           </TabsList>
 
@@ -151,12 +151,12 @@ export default function StatsWindow({ windowData }: StatsWindowProps) {
           <TabsContent value="feedback" className="mt-4">
             <Card>
               <CardHeader>
-                <CardTitle className={isMobile ? 'text-base' : ''}>Feedback Personalizado</CardTitle>
+                <CardTitle className={isMobile ? 'text-base' : ''}>Retroalimentación Personalizada</CardTitle>
                 <CardDescription className={isMobile ? 'text-sm' : ''}>Análisis de tu desempeño generado por IA</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className={`prose dark:prose-invert max-w-none ${isMobile ? 'prose-sm' : ''}`}>
-                  <p className={isMobile ? 'text-sm' : ''}>{stats?.personalized_feedback ?? "Sin feedback disponible"}</p>
+                  <p className={isMobile ? 'text-sm' : ''}>{stats?.personalized_feedback ?? "Sin retroalimentación disponible"}</p>
                 </div>
 
                 <div className={`mt-6 flex ${isMobile ? 'justify-center' : 'justify-end'}`}>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -21,6 +21,7 @@ interface Session {
   title: string
   topic: string
   text: string
+  words?: string[]
   folderId: string | null
   type: "generate" | "custom"
   createdAt: string
@@ -205,6 +206,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               title: sessionData.title || `Sesión sobre ${sessionData.topic}`,
               topic: sessionData.topic,
               text: data.text,
+              words: data.words,
               folderId: sessionData.folderId,
               type: "generate",
               createdAt: new Date().toISOString(),
@@ -236,6 +238,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const newSession: Session = {
             id,
             ...sessionData,
+            words: sessionData.text.split(/\s+/).filter(word => word.length > 0),
             createdAt: new Date().toISOString(),
             userId: userId, // Asignar userId para filtrado de seguridad
           }
@@ -506,20 +509,25 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           // If a userId is provided, sync their sessions from the API
           if (userId) {
             if (statsData.recent_sessions_stats) {
-              // Map API sessions, preserving full text if it exists locally
+              // Map API sessions, preservando datos locales cuando existan
               const apiSessions: Session[] = statsData.recent_sessions_stats.map((apiSession) => {
                 const existingSession = get().sessions.find(s => s.id === apiSession.session_id)
-                
-                const text = (existingSession && existingSession.text && existingSession.text.length > (apiSession.text_snippet?.length || 0))
-                             ? existingSession.text
-                             : (apiSession.text_snippet || "");
+
+                const text = existingSession?.text && existingSession.text.length > (apiSession.text_snippet?.length || 0)
+                  ? existingSession.text
+                  : (apiSession.text_snippet || "")
+
+                const words = existingSession?.words
+
+                const topic = existingSession?.topic || apiSession.topic || "Lectura general"
 
                 return {
                   id: apiSession.session_id,
-                  title: apiSession.topic || `Sesión de lectura (${new Date(apiSession.created_at).toLocaleDateString()})`,
-                  topic: apiSession.topic || "Lectura general",
-                  text: text, // Use preserved or snippet text
-                  folderId: null,
+                  title: existingSession?.title || apiSession.topic || `Sesión de lectura (${new Date(apiSession.created_at).toLocaleDateString()})`,
+                  topic,
+                  text,
+                  words,
+                  folderId: existingSession?.folderId || null,
                   type: "generate" as const,
                   createdAt: apiSession.created_at,
                   userId: userId,
@@ -577,16 +585,21 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
               statsData.recent_sessions_stats.forEach(apiSession => {
                 const existingSession = sessionsMap.get(apiSession.session_id);
-                
-                const text = (existingSession && existingSession.text && existingSession.text.length > (apiSession.text_snippet?.length || 0))
-                             ? existingSession.text
-                             : (apiSession.text_snippet || "");
+
+                const text = existingSession?.text && existingSession.text.length > (apiSession.text_snippet?.length || 0)
+                  ? existingSession.text
+                  : (apiSession.text_snippet || "");
+
+                const words = existingSession?.words;
+
+                const topic = existingSession?.topic || apiSession.topic || "Lectura general";
 
                 const sessionData: Session = {
                   id: apiSession.session_id,
-                  title: apiSession.topic || `Sesión de lectura (${new Date(apiSession.created_at).toLocaleDateString()})`,
-                  topic: apiSession.topic || "Lectura general",
-                  text: text, // Use preserved or snippet text
+                  title: existingSession?.title || apiSession.topic || `Sesión de lectura (${new Date(apiSession.created_at).toLocaleDateString()})`,
+                  topic,
+                  text,
+                  words,
                   folderId: existingSession?.folderId || null,
                   type: "generate" as const,
                   createdAt: apiSession.created_at,


### PR DESCRIPTION
## Summary
- preserve session topic, text and words when syncing stats
- keep sessions sorted by creation date
- store words for new sessions
- localize stats window and UI controls in Spanish

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c01cec94832f8dd7cbe80688be86