### PR TITLE
Fix viewport height for mobile scrolling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
 
   return (
     <main
-      className="grid h-screen overflow-hidden bg-slate-50 dark:bg-slate-950 lg:grid-cols-[16rem_1fr]"
+      className="grid min-h-svh overflow-y-auto bg-slate-50 dark:bg-slate-950 lg:grid-cols-[16rem_1fr]"
     >
       <Sidebar
         open={sidebarOpen}

--- a/components/window-frame.tsx
+++ b/components/window-frame.tsx
@@ -224,10 +224,14 @@ export default function WindowFrame({
           </button>
         </div>
       </div>
-      <div className={cn(
-        "overflow-auto",
-        isMobile ? "p-4 h-[calc(100vh-60px)]" : "p-4 h-[calc(100%-40px)]"
-      )}>
+        <div
+          className={cn(
+            "overflow-auto",
+            isMobile
+              ? "p-4 h-[calc(var(--viewport-height)-60px)]"
+              : "p-4 h-[calc(100%-40px)]"
+          )}
+        >
         {children}
       </div>
     </Rnd>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -47,6 +47,7 @@ body {
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --viewport-height: 100dvh;
   }
   .dark {
     --background: 0 0% 3.9%;


### PR DESCRIPTION
## Summary
- adjust page layout to use `min-h-svh` and `overflow-y-auto`
- define `--viewport-height` CSS variable using `100dvh`
- reference `--viewport-height` in window frame for mobile view

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ba8c71a40832f9f879fa0a1526b8b