### PR TITLE
Connect dashboard to stats endpoint

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
 import { BookOpen, BarChart3, History, Sparkles, Clock, TrendingUp, Brain, PlusCircle, Activity } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
 import MetricsOverview from "@/components/metrics-overview"
 import RecentSessions from "@/components/recent-sessions"
 import StatsHistory from "@/components/stats-history"
@@ -39,10 +40,12 @@ export default function Dashboard({ setActiveView, activeTab, setActiveTab }: Da
   const [newProjectName, setNewProjectName] = useState("")
   const [newProjectFolder, setNewProjectFolder] = useState("")
   const [isNewProjectDialogOpen, setIsNewProjectDialogOpen] = useState(false)
-  const { addSession, folders, addProject } = useWorkspaceStore()
+  const { addSession, folders, addProject, userStats, isLoadingStats } = useWorkspaceStore()
   const { user, token } = useAuthStore()
   const { toast } = useToast()
   const { isMobile, isTablet } = useBreakpoint()
+
+  const overall = userStats?.overall_stats
 
   const handleCreateSession = async (type: "generate" | "custom") => {
     if (type === "generate" && !topic.trim()) {
@@ -323,7 +326,9 @@ export default function Dashboard({ setActiveView, activeTab, setActiveTab }: Da
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">300-500 WPM</div>
+                  <div className="text-2xl font-bold">
+                    {overall ? `${overall.average_wpm} WPM` : <Skeleton className="h-6 w-24" />}
+                  </div>
                   <p className="text-xs text-slate-500 mt-1">Mejora tu velocidad con práctica regular</p>
                 </CardContent>
               </Card>
@@ -336,7 +341,9 @@ export default function Dashboard({ setActiveView, activeTab, setActiveTab }: Da
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">+15% WPM</div>
+                  <div className="text-2xl font-bold">
+                    {overall ? `${overall.delta_wpm_vs_previous >= 0 ? '+' : ''}${Math.round(overall.delta_wpm_vs_previous)}% WPM` : <Skeleton className="h-6 w-20" />}
+                  </div>
                   <p className="text-xs text-slate-500 mt-1">Incremento promedio después de 10 sesiones</p>
                 </CardContent>
               </Card>
@@ -349,7 +356,9 @@ export default function Dashboard({ setActiveView, activeTab, setActiveTab }: Da
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold">85%</div>
+                  <div className="text-2xl font-bold">
+                    {overall ? `${Math.round(overall.average_quiz_score)}%` : <Skeleton className="h-6 w-12" />}
+                  </div>
                   <p className="text-xs text-slate-500 mt-1">Retención promedio con técnica RSVP</p>
                 </CardContent>
               </Card>

--- a/lib/rsvpApi.ts
+++ b/lib/rsvpApi.ts
@@ -84,11 +84,17 @@ export interface StatsResponse {
   user_id: string
   overall_stats: {
     total_sessions_read: number
-  total_reading_time_seconds: number
+    total_reading_time_seconds: number
     total_words_read: number
     average_wpm: number
     total_quizzes_taken: number
     average_quiz_score: number
+    delta_wpm_vs_previous: number
+    delta_comprehension_vs_previous: number
+    delta_reading_time_vs_previous: number
+    reading_progress_percent: number
+    wpm_trend: "up" | "down" | "stable"
+    comprehension_trend: "up" | "down" | "stable"
   }
   recent_sessions_stats: {
     session_id: string
@@ -101,6 +107,7 @@ export interface StatsResponse {
     ai_text_difficulty: string
     ai_estimated_ideal_reading_time_seconds: number
     created_at: string
+    created_at_local: string
     topic?: string // Topic real de la sesión (opcional por compatibilidad)
   }[]
   personalized_feedback: string | null


### PR DESCRIPTION
## Summary
- add extra metrics to `StatsResponse`
- display real stats in dashboard overview cards
- integrate stats endpoint in stats history graphs and trends
- enrich server session cards with snippet details
- wrap server stats section in a fragment to fix JSX build error

## Testing
- `pnpm run lint`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ca884bc34832fac927f8d6ac208fd